### PR TITLE
Implement default values for source definitions.

### DIFF
--- a/docs/api-source-definitions.html
+++ b/docs/api-source-definitions.html
@@ -85,7 +85,7 @@ const manager = new Manager({
 
 // Define your sources
 manager.drivers.fromSuperagent([
-  // Jump below this definition for concise examples.
+  // Jump below this first definition for concise examples.
   {
     // 'meta' is driver-specific implementation data. The below `meta` object
     // is for the superagent driver only.
@@ -115,8 +115,6 @@ manager.drivers.fromSuperagent([
     // 'params' specifies **required parameters** for this source.  If
     // undefined this source has no required parameters.
     //
-    // This **must** always be an array of strings.
-    //
     // When a source definition has required params **only queries with these
     // params will be considered**.
     //
@@ -134,10 +132,22 @@ manager.drivers.fromSuperagent([
     //  })
     //
     // For more information on creating queries see API-DECORATOR.md
+    //
+    // If defined this can be:
+    //
+    // - An array of strings
+    // - An object where keys represent names and values represent defaults
+    //
+    // See below for examples.
     params: ['id'],
 
     // 'optionalParams' specifies optional params for a source.  These do not
     // need to be specified in a query to use this source.
+    //
+    // If defined this can be:
+    //
+    // - An array of strings
+    // - An object where keys represent names and values represent defaults
     optionalParams: ['foo'],
 
     // 'returns' specifies what data this source definition returns. Some API
@@ -207,6 +217,9 @@ manager.drivers.fromSuperagent([
     // This may be omitted; the default is 'GET'.
     queryType: 'GET'
   },
+
+  // Concise examples
+
   // bare minimum GET query
   {
     meta: {
@@ -214,6 +227,18 @@ manager.drivers.fromSuperagent([
     },
     returns: UserModel.list(),
   },
+
+  // default values in params
+  {
+    meta: {
+      url: '/api/v1/users/:id/:operation',
+    },
+    params: {
+      id: undefined, // no default ID; must be supplied.
+      operation: 'posts', // defaults to 'posts' but overridden if supplied
+    },
+  }
+
   // this API endpoint creates a new user
   {
     // 'meta' holds driver-specific data
@@ -224,6 +249,7 @@ manager.drivers.fromSuperagent([
     queryType: 'CREATE',
     returns: UserModel.item(),
   },
+
   // this API endpoint deletes a user
   {
     // 'meta' holds driver-specific data

--- a/docs/markdown/api-source-definitions.md
+++ b/docs/markdown/api-source-definitions.md
@@ -31,7 +31,7 @@ const manager = new Manager({
 
 // Define your sources
 manager.drivers.fromSuperagent([
-  // Jump below this definition for concise examples.
+  // Jump below this first definition for concise examples.
   {
     // 'meta' is driver-specific implementation data. The below `meta` object
     // is for the superagent driver only.
@@ -61,8 +61,6 @@ manager.drivers.fromSuperagent([
     // 'params' specifies **required parameters** for this source.  If
     // undefined this source has no required parameters.
     //
-    // This **must** always be an array of strings.
-    //
     // When a source definition has required params **only queries with these
     // params will be considered**.
     //
@@ -80,10 +78,22 @@ manager.drivers.fromSuperagent([
     //  })
     //
     // For more information on creating queries see API-DECORATOR.md
+    //
+    // If defined this can be:
+    //
+    // - An array of strings
+    // - An object where keys represent names and values represent defaults
+    //
+    // See below for examples.
     params: ['id'],
 
     // 'optionalParams' specifies optional params for a source.  These do not
     // need to be specified in a query to use this source.
+    //
+    // If defined this can be:
+    //
+    // - An array of strings
+    // - An object where keys represent names and values represent defaults
     optionalParams: ['foo'],
 
     // 'returns' specifies what data this source definition returns. Some API
@@ -153,6 +163,9 @@ manager.drivers.fromSuperagent([
     // This may be omitted; the default is 'GET'.
     queryType: 'GET'
   },
+
+  // Concise examples
+
   // bare minimum GET query
   {
     meta: {
@@ -160,6 +173,18 @@ manager.drivers.fromSuperagent([
     },
     returns: UserModel.list(),
   },
+
+  // default values in params
+  {
+    meta: {
+      url: '/api/v1/users/:id/:operation',
+    },
+    params: {
+      id: undefined, // no default ID; must be supplied.
+      operation: 'posts', // defaults to 'posts' but overridden if supplied
+    },
+  }
+
   // this API endpoint creates a new user
   {
     // 'meta' holds driver-specific data
@@ -170,6 +195,7 @@ manager.drivers.fromSuperagent([
     queryType: 'CREATE',
     returns: UserModel.item(),
   },
+
   // this API endpoint deletes a user
   {
     // 'meta' holds driver-specific data

--- a/packages/tectonic/NOTES.md
+++ b/packages/tectonic/NOTES.md
@@ -35,3 +35,42 @@ We can also:
 - Inspect the query parameters of the query call
   - If the query parameter matches an ID pre-empt the API call and look in the
 	cache
+
+## Default parametrs
+
+**Challenge**: Queries with and without default parameters should use caching
+equally.
+
+From here on out the term "user-generated query" refers to a query with a
+subset of parameters filled _without_ default parameters added. The "
+supplemented query" refers to a query with a subset of parameters filled _with_
+default parameters added.
+
+Problem story:
+
+1. Queries are cached by their `.toString()` value as the lookup key.  
+2. To determine whether a query can be pulled from the cache we use the
+   `.toString()` key to look up data
+3. Polluting a query with default parameters prior to saving in the cache
+   will remove the ability to look up cache information for partial queries
+
+All things said, this is purely a resolver issue: it's the resolver's job
+to tie together source definitions, queries and the cache.
+  
+**Options**:
+1. Save the user-generated query plus the supplemented query in the cache. We
+   can then look up both in the cache during resolving immediately without
+   any action; the resolution process will be short circuited before even
+   processing sources for a query as the query's toString value will be in the
+   cache.
+
+2. Run the resolver as per usual, looking up the user-generated query in the
+   cache. This won't be hit, as it has no default params.
+   Once a source definition is found, fill in the defaults to create a
+   supplemented query then look this query up in the cache.
+   If so, then short circuit.  This splits the cache lookup into two separate
+   places in the code.
+
+   Only store the supplemented query in the cache.
+
+   Pros: matches all variations of user-defined queries without defaults

--- a/packages/tectonic/package.json
+++ b/packages/tectonic/package.json
@@ -7,7 +7,7 @@
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
     "lint": "$(npm bin)/eslint ./src",
     "prepublish": "$(npm bin)/babel -d transpiled src",
-    "test": "$(npm bin)/mocha --compilers js:babel-register --recursive --require ./test/_setup.js ./test/specs/**/*.js"
+    "test": "$(npm bin)/mocha --compilers js:babel-register --recursive --require ./test/_setup.js ./test/specs"
   },
   "repository": {
     "type": "git",

--- a/packages/tectonic/src/cache/index.js
+++ b/packages/tectonic/src/cache/index.js
@@ -266,7 +266,7 @@ export default class Cache {
 
   /**
    * getQueryData inspects the given state for the current model for the
-   * necessary data and returns it if so.
+   * necessary data and returns it if all requirements are met.
    *
    * @param Query  Query, which must have a filled .returnedIds
    * @param Map    Tectonic's reducer state (store.getState().tectonic)
@@ -288,6 +288,8 @@ export default class Cache {
 
     // No IDs were returned when we queried for this item
     if (returnedIds.size === 0) {
+      // ensure we return a consistent default; RETURNS_ITEM will always use
+      // a blank model but we need to return a list for RETURNS_LIST.
       const returns = (query.returnType === RETURNS_LIST) ? [] : undefined;
       return [returns, true];
     }

--- a/packages/tectonic/src/query/index.js
+++ b/packages/tectonic/src/query/index.js
@@ -96,6 +96,7 @@ export default class Query {
   queryType: QueryType
   returnType: ?ReturnType
   body: any
+  // params contains both required and optional params
   params: ParamsType = {}
   // TODO: ReturnsNoFields, for deletes. This shouldn't be "undefined"
   fields: Array<string> | ReturnsAllFields

--- a/packages/tectonic/src/resolver/utils.js
+++ b/packages/tectonic/src/resolver/utils.js
@@ -2,10 +2,8 @@
 
 import Query from '../query';
 import SourceDefinition, {
-  assignDefaultParams
+  assignDefaultParams,
 } from '../sources/definition';
-
-import type { ParamsType } from '../consts';
 
 // TODO:
 // - `doesSourceSatisfySomeQueryFields` for partial matching

--- a/packages/tectonic/src/sources/definition.js
+++ b/packages/tectonic/src/sources/definition.js
@@ -147,6 +147,7 @@ export default class SourceDefinition {
   // addDefaultParams adds missing params and optionalParams to a query
   // given the defaults provided in the source definition.
   addDefaultParams(q: Query) {
+    // eslint-disable-next-line
     q.params = assignDefaultParams(this, q.params);
   }
 

--- a/packages/tectonic/src/sources/provider.js
+++ b/packages/tectonic/src/sources/provider.js
@@ -36,9 +36,12 @@ export default class Provider {
 
     if (fields === '*') {
       this.fields = fields;
-      return;
+    } else {
+      this.setFieldSubsets(fields, model);
     }
+  }
 
+  setFieldSubsets(fields: Array<string> | string, model: Class<Model>) {
     // If this only returns a single field we should wrap it in an array.
     if (typeof fields === 'string') {
       fields = [fields];

--- a/packages/tectonic/test/specs/resolver/utils.js
+++ b/packages/tectonic/test/specs/resolver/utils.js
@@ -101,6 +101,47 @@ describe('resolver utils', () => {
       });
       assert.isFalse(utils.doesSourceSatisfyQueryParams(s, q));
     });
+
+    it('returns false when the source has defaults but the query is still missing required fields', () => {
+      const s = new SourceDefinition({
+        id: 1,
+        returns: User.item(),
+        meta: {},
+        params: {
+          id: undefined,
+          foo: 'bar',
+        },
+        optionalParams: ['limit']
+      });
+
+      const q = new Query({
+        model: User,
+        fields: RETURNS_ALL_FIELDS,
+        returnType: RETURNS_ITEM,
+        params: { foo: 'baz' } // missing 'id' without a default
+      });
+      assert.isFalse(utils.doesSourceSatisfyQueryParams(s, q));
+    });
+
+    it('returns true when the source has defaults which the query is missing', () => {
+      const s = new SourceDefinition({
+        id: 1,
+        returns: User.item(),
+        meta: {},
+        params: {
+          id: undefined,
+          foo: 'bar',
+        },
+        optionalParams: ['limit']
+      });
+      const q = new Query({
+        model: User,
+        fields: RETURNS_ALL_FIELDS,
+        returnType: RETURNS_ITEM,
+        params: { id: 1 }
+      });
+      assert.isTrue(utils.doesSourceSatisfyQueryParams(s, q));
+    });
   });
 
   describe('doesSourceSatisfyAllQueryFields', () => {

--- a/packages/tectonic/test/specs/sources/definitions.js
+++ b/packages/tectonic/test/specs/sources/definitions.js
@@ -2,6 +2,8 @@
 
 import { assert } from 'chai';
 import SourceDefinition from '../../../src/sources/definition.js';
+import Query from '../../../src/query';
+import Model from '../../../src/model';
 import { User, Post } from '../../models';
 import { GET, UPDATE, CREATE, DELETE, RETURNS_NONE } from '../../../src/consts';
 
@@ -22,6 +24,59 @@ describe('SourceDefinition', () => {
         queryType: DELETE
       });
       assert.equal(sd.providers.returnsNone, true);
+    });
+  });
+
+  describe('normalizeParams', () => {
+    it('normalizes an array of params to an object of undefined default values', () => {
+      const input = ['a', 'b'];
+      const expected = {a: undefined, b: undefined};
+      assert.deepEqual(SourceDefinition.normalizeParams(input), expected);
+    });
+
+    it('converts a string', () => {
+      const input = 'a';
+      const expected = {a: undefined};
+      assert.deepEqual(SourceDefinition.normalizeParams(input), expected);
+    });
+  });
+
+  describe('addDefaultParams', () => {
+    it('adds required params to a query', () => {
+      // minimum required constructor opts
+      const params = {
+        foo: 'ruffleburg',
+      };
+
+      const q = new Query({ model: User, queryType: 'GET' });
+      const sd = new SourceDefinition({
+        meta: {},
+        returns: User.item(),
+        params,
+      });
+
+      assert.deepEqual(q.params, {});
+      sd.addDefaultParams(q);
+      console.log(params, "QUERY NEXT", q.params);
+      assert.deepEqual(q.params, params);
+    });
+
+    it('adds optional params to a query', () => {
+      // minimum required constructor opts
+      const params = {
+        foo: 'ruffleburg',
+      };
+
+      const q = new Query({ model: User, queryType: 'GET' });
+      const sd = new SourceDefinition({
+        meta: {},
+        returns: User.item(),
+        optionalParams: params,
+      });
+
+      assert.deepEqual(q.params, {});
+      sd.addDefaultParams(q);
+      assert.deepEqual(q.params, params);
     });
   });
 
@@ -85,22 +140,22 @@ describe('SourceDefinition', () => {
   });
 
   describe('param normalization', () => {
-    it('turns a single param into an array', () => {
+    it('turns params into an object', () => {
       const def = new SourceDefinition({
-        params: 'id',
+        params: ['id'],
         returns: User.item(),
         meta: {}
       });
-      assert.deepEqual(def.params, ['id']);
+      assert.deepEqual(def.params, {'id': undefined});
     });
 
-    it('turns a single optionalParam into an array', () => {
+    it('turns optionalParams into an object', () => {
       const def = new SourceDefinition({
-        optionalParams: 'id',
+        optionalParams: ['id'],
         returns: User.item(),
         meta: {}
       });
-      assert.deepEqual(def.optionalParams, ['id']);
+      assert.deepEqual(def.optionalParams, {'id': undefined});
     });
   });
 


### PR DESCRIPTION
Fixes #40.

This commit implements the entirety of default parameters for queries.

During normal resolution a query is matched againsnt source definitions
until a valid source definition is found (we circuit-break to the first
valid).

If the query hasn't specified parameters with defaults for the valid
source defintiion the query will be supplemented with the defaults from
the source definition.

The supplemented query's hash from .toString() will be stored in the
cache, therefore each resolution now has two cache lookups:  once for
the user-generated query and once for the supplemented query with
defaults.  This happens prior to calling the source definition for a
query so we can use the cache for existing data.

Ensure that a query satisfies a source when it omits required params
with defaults.

