### PR TITLE
Conditional polling bug fix

### DIFF
--- a/packages/tectonic/src/decorator/index.js
+++ b/packages/tectonic/src/decorator/index.js
@@ -118,7 +118,11 @@ export default function load(loadQueries: { [key: string]: Query } | Function = 
           // query statuses for successful queries and not re-query them even if
           // the cache is now invalid
           Object.keys(newQueries).forEach((q) => {
-            this.queries[q].params = newQueries[q].params;
+            if (this.queries[q]) {
+              this.queries[q].params = newQueries[q].params;
+            } else {
+              this.queries[q] = newQueries[q];
+            }
           });
 
           debug('computed new queries for component', this.queries);


### PR DESCRIPTION
In the following example, if `props.fetchMore` is `false` initially and `true` later on, `componentWillReceiveProps` will error out while attempting to reassign `newQueries` params.

```javascript
@load(props => {
  if (props.fetchMore) {
    return {
        model1: model1.getItem(),
        model2: model2.getItem()
    }
  }
  return {
      model1: model1.getItem()
  }
})
```