### PR TITLE
Add removing of unspecified params

### DIFF
--- a/packages/tectonic-superagent/src/index.js
+++ b/packages/tectonic-superagent/src/index.js
@@ -16,7 +16,9 @@ export default class TectonicSuperagent {
         meta: { url, transform, method, headers, request }
       } = sourceDef;
 
-      url = inst.parseUrlParams({ url, query });
+      url = inst.parseUrlParams({ url, query }, opts);
+      url = inst.removeUnspecifiedParams(url, opts)
+      console.log(url)
       // Normalize method type
       method = method ? method.toUpperCase() : 'GET';
 
@@ -78,4 +80,30 @@ export default class TectonicSuperagent {
     return url;
   }
 
+  /**
+   * Removes unspecified params. It can remove them all (unsafe), or remove if
+   * it's the last param.
+   * @param {string} url
+   * @param {string} type
+   */
+  removeUnspecifiedParams (url, { removeParams }) {
+    const unspec = '/undefined'
+    const isLast = (url, unspec) => {
+      return url.length - url.indexOf(unspec) - unspec.length === 0
+    }
+
+    switch (removeParams) {
+      case 'unsafe':
+        return url.replace(unspec, '')
+      case 'safe':
+        const index = url.indexOf(unspec)
+        if (index === -1) return url
+        else if (!isLast(url, unspec)) throw new Error('Unspecified param')
+        else return url.replace(unspec, '')
+      case undefined:
+        return url
+      default:
+        throw new Error('Invalid removeParams option')
+    }
+  }
 }


### PR DESCRIPTION
Related to this [enhancement issue](https://github.com/tonyhb/tectonic/issues/41).

The user can now specify the type of param removal. There are two types:

- unsafe - Will remove all unspecified params from the url regardless of their position
- safe - Will remove the param only if it's the last one, if it's not it will throw

Param removal is specified at the instantiation of TectonicSuperagent like this:
`new TectonicSuperagent({ removeParams: 'unsafe' || 'safe' })`

For simple urls like `'api/v1/user/:id'` it is ok to use unsafe type (or it's not?) but for more complex urls like `'api/v1/user/:id/:name'` or `'api/v1/user/:id/comments'` that will not work. If the param is removed the order is changed. Safe removal of params will then throw.
