### PR TITLE
Add custom caching on a per-model and per-source def basis

### DIFF
--- a/packages/tectonic/.babelrc
+++ b/packages/tectonic/.babelrc
@@ -1,10 +1,10 @@
 {
   "presets": ["es2015", "react", "stage-0"],
   "plugins": [
-    "transform-decorators",
     "syntax-decorators",
     "transform-decorators-legacy",
     "transform-flow-strip-types",
+    "transform-decorators-legacy"
   ],
   "sourceRoot": "."
 }

--- a/packages/tectonic/CACHING.md
+++ b/packages/tectonic/CACHING.md
@@ -37,3 +37,31 @@ In short:
 1. The decorator resolves queries into a tree of dependencies when the component
    is created
 2. When a query is resolved and is successful we attempt to resolve its children
+
+### Custom caching
+
+From tectonic 2.1 it's possible to set custom cache information for your models
+and sources.  This allows you to minimize network requests and ensure that
+queries will be resolved from the cache.
+
+Custom cache information can be set on a source definition or model.  If the
+cache sees that one of these is set, the cache TTL will be modified
+accordingly.  If both are set the lowest value will be used.
+
+The cache property is always an integer representing the number of seconds to
+cache.
+
+#### Model caching
+
+Setting the `static cacheFor` property in a model ensures that all models of
+this type will be cached for the given number of seconds across all source
+definitions.
+
+Note that if a source definition specifies a lower cacheFor TTL, the lower
+value from the source definition will be used.
+
+#### Source definition caching
+
+Source definition caching allows you to specificy custom cache durations for
+each API endpoint.  This gives you custom granularity on a per-url basis for
+how long we should cache your data.

--- a/packages/tectonic/package.json
+++ b/packages/tectonic/package.json
@@ -5,9 +5,9 @@
   "main": "transpiled/index.js",
   "scripts": {
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
-    "lint": "$(npm bin)/eslint ./src",
-    "prepublish": "$(npm bin)/babel -d transpiled src",
-    "test": "$(npm bin)/mocha --compilers js:babel-register --recursive --require ./test/_setup.js ./test/specs"
+    "lint": "eslint ./src",
+    "prepublish": "babel -d transpiled src",
+    "test": "mocha --compilers js:babel-register --recursive --require ./test/_setup.js ./test/specs"
   },
   "repository": {
     "type": "git",
@@ -34,7 +34,6 @@
     "babel-eslint": "^7.0.0",
     "babel-plugin-syntax-decorators": "^6.13.0",
     "babel-plugin-syntax-flow": "^6.13.0",
-    "babel-plugin-transform-decorators": "^6.13.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-flow-strip-types": "^6.14.0",
     "babel-preset-es2015": "^6.5.0",

--- a/packages/tectonic/src/cache/index.js
+++ b/packages/tectonic/src/cache/index.js
@@ -141,6 +141,14 @@ export default class Cache {
           throw new Error('Error attempting to parse model data with no key', sourceDef, apiResponse);
         }
 
+        // Calculate the expiry from the source definition and model, if applicable.
+        // Use the lowest TTL.
+        const sec = [provider.model.cacheFor, sourceDef.cacheFor].sort().shift();
+        if (sec !== undefined && sec !== null) {
+          expires = new Date();
+          expires.setSeconds(sec);
+        }
+
         if (sourceDef.isPolymorphic()) {
           // Fail as described in the scenario above; this polymorphic API
           // response needs an object

--- a/packages/tectonic/src/model/index.js
+++ b/packages/tectonic/src/model/index.js
@@ -66,6 +66,14 @@ export default class Model {
 
   static submodelFields: Array<string>;
 
+  /**
+   * cacheFor represents the number of seconds this model should be cached for.
+   *
+   * If defined, this is used as explained in [CACHING.md] - Custom Caching -
+   * to configure custom cache times within our state.
+   */
+  static cacheFor = undefined;
+
   record: Record<*>;
 
 

--- a/packages/tectonic/src/sources/definition.js
+++ b/packages/tectonic/src/sources/definition.js
@@ -26,6 +26,9 @@ export type SourceDefinitionOpts = {
   // this is typically resolved from the Returns parameter
   model: ?Class<Model>;
   queryType: QueryType;
+
+  // cacheFor may be set, defining the TTL for the response in seconds
+  cacheFor: ?number;
 };
 
 /**
@@ -40,6 +43,8 @@ export default class SourceDefinition {
   model: Array<Class<Model>>
   driverFunc: Function
   queryType: QueryType
+
+  cacheFor: ?number
 
   /**
    * Object of **required** parameters for the source (where values are defaults).
@@ -81,6 +86,7 @@ export default class SourceDefinition {
     driverFunc,
     model,
     queryType = GET,
+    cacheFor,
   }: SourceDefinitionOpts = {}) {
     if (id === undefined) {
       id = Math.floor(Math.random() * (1 << 30)).toString(16);
@@ -102,6 +108,7 @@ export default class SourceDefinition {
     // Which CRUD action this refers to
     this.queryType = queryType;
     this.setModelProperty(model);
+    this.cacheFor = cacheFor;
 
     // ensure that after setting properties the definition is valid
     this.validate();

--- a/packages/tectonic/test/specs/cache/apiData.js
+++ b/packages/tectonic/test/specs/cache/apiData.js
@@ -113,6 +113,7 @@ describe('parsing cache data', () => {
   });
 
   describe('parseApiData', () => {
+
     it('parses a polymorphic returns correctly', () => {
       const sd = new SourceDefinition({
         returns: {
@@ -163,6 +164,141 @@ describe('parsing cache data', () => {
         expected
       );
     });
+
+    it('sets expiry from sourceDef.cacheFor', () => {
+      const sd = new SourceDefinition({
+        returns: new Provider(User, RETURNS_ALL_FIELDS, RETURNS_ITEM),
+        meta: {},
+        cacheFor: 600,
+      });
+      const apiResponse = {
+        id: 1,
+        name: 'foo',
+        email: 'foo@bar.com'
+      };
+      const expires = new Date();
+      expires.setSeconds(600);
+
+      const expected = {
+        user: {
+          1: {
+            data: apiResponse,
+            cache: { expires }
+          }
+        }
+      };
+      const actual = cache.parseApiData(User.getItem(), sd, apiResponse, expires);
+
+      assert.closeTo(
+        expected.user[1].cache.expires.getTime(),
+        actual.user[1].cache.expires.getTime(),
+        100,
+        "Times are within 100ms as expected",
+      );
+      expected.user[1].cache.expires = actual.user[1].cache.expires;
+      assert.deepEqual(expected, actual);
+    });
+
+    it('sets expiry from Model.cacheFor', () => {
+      User.cacheFor = 900;
+      const sd = new SourceDefinition({
+        returns: new Provider(User, RETURNS_ALL_FIELDS, RETURNS_ITEM),
+        meta: {},
+      });
+      const apiResponse = {
+        id: 1,
+        name: 'foo',
+        email: 'foo@bar.com'
+      };
+      const expires = new Date();
+      expires.setSeconds(900);
+      const expected = {
+        user: {
+          1: {
+            data: apiResponse,
+            cache: { expires }
+          }
+        }
+      };
+      const actual = cache.parseApiData(User.getItem(), sd, apiResponse, expires);
+      assert.closeTo(
+        expected.user[1].cache.expires.getTime(),
+        actual.user[1].cache.expires.getTime(),
+        100,
+        "Times are within 100ms as expected",
+      );
+      expected.user[1].cache.expires = actual.user[1].cache.expires;
+      assert.deepEqual(expected, actual);
+      User.cacheFor = undefined;
+    });
+
+    it('uses the lowest expiry from sourceDef.cacheFor and model.cacheFor', () => {
+      const sd = new SourceDefinition({
+        returns: new Provider(User, RETURNS_ALL_FIELDS, RETURNS_ITEM),
+        meta: {},
+        cacheFor: 600,
+      });
+      User.cacheFor = 900;
+      const apiResponse = {
+        id: 1,
+        name: 'foo',
+        email: 'foo@bar.com'
+      };
+      const expires = new Date();
+      expires.setSeconds(600);
+      const expected = {
+        user: {
+          1: {
+            data: apiResponse,
+            cache: { expires }
+          }
+        }
+      };
+      const actual = cache.parseApiData(User.getItem(), sd, apiResponse, expires);
+      assert.closeTo(
+        expected.user[1].cache.expires.getTime(),
+        actual.user[1].cache.expires.getTime(),
+        100,
+        "Times are within 100ms as expected",
+      );
+      expected.user[1].cache.expires = actual.user[1].cache.expires;
+      assert.deepEqual(expected, actual);
+      User.cacheFor = undefined;
+    });
+
+    it('sets expiry from Model.cacheFor', () => {
+      User.cacheFor = 900;
+      const sd = new SourceDefinition({
+        returns: new Provider(User, RETURNS_ALL_FIELDS, RETURNS_ITEM),
+        meta: {},
+      });
+      const apiResponse = {
+        id: 1,
+        name: 'foo',
+        email: 'foo@bar.com'
+      };
+      const expires = new Date();
+      expires.setSeconds(900);
+      const expected = {
+        user: {
+          1: {
+            data: apiResponse,
+            cache: { expires }
+          }
+        }
+      };
+      const actual = cache.parseApiData(User.getItem(), sd, apiResponse, expires);
+      assert.closeTo(
+        expected.user[1].cache.expires.getTime(),
+        actual.user[1].cache.expires.getTime(),
+        100,
+        "Times are within 100ms as expected",
+      );
+      expected.user[1].cache.expires = actual.user[1].cache.expires;
+      assert.deepEqual(expected, actual);
+      User.cacheFor = undefined;
+    });
+
   });
 
   describe('sets Query.returnedIds', () => {


### PR DESCRIPTION
This allows you to store data in the reducer for a custom amount of
seconds, disregarding the cache headers from the server.