### PR TITLE
#87 Added fix for not fetching new data when params were changed

### DIFF
--- a/packages/tectonic/src/cache/index.js
+++ b/packages/tectonic/src/cache/index.js
@@ -83,7 +83,7 @@ export default class Cache {
       return;
     }
 
-    let data;
+    let data = {};
     if (apiResponse) {
       data = this.parseApiData(query, sourceDef, apiResponse, expires);
     }

--- a/packages/tectonic/src/decorator/index.js
+++ b/packages/tectonic/src/decorator/index.js
@@ -120,15 +120,18 @@ export default function load(loadQueries: { [key: string]: Query } | Function = 
           // Assign the props newQueries to this.queries; this is gonna retain
           // query statuses for successful queries and not re-query them even if
           // the cache is now invalid
+          let haveNewQueries = false
           Object.keys(newQueries).forEach((q) => {
-            if (!this.queries[q].is(newQueries[q])) {
+            if (!this.queries[q] || !this.queries[q].is(newQueries[q])) {
+              haveNewQueries = true
               this.queries[q] = newQueries[q];
             }
           });
 
           debug('computed new queries for component', this.queries);
 
-          this.addAndResolveQueries();
+          if (haveNewQueries)
+            this.addAndResolveQueries();
         }
       }
 

--- a/packages/tectonic/src/decorator/index.js
+++ b/packages/tectonic/src/decorator/index.js
@@ -121,9 +121,7 @@ export default function load(loadQueries: { [key: string]: Query } | Function = 
           // query statuses for successful queries and not re-query them even if
           // the cache is now invalid
           Object.keys(newQueries).forEach((q) => {
-            if (this.queries[q] && deepEqual(this.queries[q].params, newQueries[q].params)) {
-              this.queries[q].params = newQueries[q].params;
-            } else {
+            if (!this.queries[q].is(newQueries[q])) {
               this.queries[q] = newQueries[q];
             }
           });

--- a/packages/tectonic/src/decorator/index.js
+++ b/packages/tectonic/src/decorator/index.js
@@ -2,6 +2,7 @@
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import deepEqual from 'deep-equal';
 import { Map } from 'immutable';
 import d from 'debug';
 
@@ -120,7 +121,7 @@ export default function load(loadQueries: { [key: string]: Query } | Function = 
           // query statuses for successful queries and not re-query them even if
           // the cache is now invalid
           Object.keys(newQueries).forEach((q) => {
-            if (this.queries[q]) {
+            if (this.queries[q] && deepEqual(this.queries[q].params, newQueries[q].params)) {
               this.queries[q].params = newQueries[q].params;
             } else {
               this.queries[q] = newQueries[q];

--- a/packages/tectonic/src/decorator/index.js
+++ b/packages/tectonic/src/decorator/index.js
@@ -2,7 +2,6 @@
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import deepEqual from 'deep-equal';
 import { Map } from 'immutable';
 import d from 'debug';
 
@@ -120,18 +119,19 @@ export default function load(loadQueries: { [key: string]: Query } | Function = 
           // Assign the props newQueries to this.queries; this is gonna retain
           // query statuses for successful queries and not re-query them even if
           // the cache is now invalid
-          let haveNewQueries = false
+          let haveNewQueries = false;
           Object.keys(newQueries).forEach((q) => {
             if (!this.queries[q] || !this.queries[q].is(newQueries[q])) {
-              haveNewQueries = true
+              haveNewQueries = true;
               this.queries[q] = newQueries[q];
             }
           });
 
           debug('computed new queries for component', this.queries);
 
-          if (haveNewQueries)
+          if (haveNewQueries) {
             this.addAndResolveQueries();
+          }
         }
       }
 

--- a/packages/tectonic/src/reducer/index.js
+++ b/packages/tectonic/src/reducer/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { Map } from 'immutable';
+import { Map, fromJS } from 'immutable';
 
 export const UPDATE_QUERY_STATUSES = '@@tectonic/update-query-statuses';
 export const UPDATE_DATA = '@@tectonic/update-data';
@@ -63,7 +63,9 @@ const reducer = (state: Object = defaultState, action: ActionObject) => {
     const { query, data, expires } = action.payload;
 
     return state.withMutations((s) => {
-      s.mergeDeep({ data });
+      Object.keys(data).forEach(key => {
+        s.mergeIn(['data', key], fromJS(data[key]));
+      })
       s.setIn(['queriesToIds', query.toString()], query.returnedIds);
       s.setIn(['queriesToExpiry', query.toString()], expires);
       s.setIn(['status', query.toString()], { status: 'SUCCESS' });

--- a/packages/tectonic/src/reducer/index.js
+++ b/packages/tectonic/src/reducer/index.js
@@ -63,9 +63,9 @@ const reducer = (state: Object = defaultState, action: ActionObject) => {
     const { query, data, expires } = action.payload;
 
     return state.withMutations((s) => {
-      Object.keys(data).forEach(key => {
+      Object.keys(data).forEach((key) => {
         s.mergeIn(['data', key], fromJS(data[key]));
-      })
+      });
       s.setIn(['queriesToIds', query.toString()], query.returnedIds);
       s.setIn(['queriesToExpiry', query.toString()], expires);
       s.setIn(['status', query.toString()], { status: 'SUCCESS' });

--- a/packages/tectonic/src/sources/definition.js
+++ b/packages/tectonic/src/sources/definition.js
@@ -183,7 +183,7 @@ export default class SourceDefinition {
    * and all of the models it returns.
    *
    */
-  getCacheFor(): number {
+  getCacheFor(): ?number {
     const ttl = [this.cacheFor];
     this.model.forEach(m => ttl.push(m.cacheFor));
     return ttl.sort().shift();


### PR DESCRIPTION
1. Fixes issue #87, New queries were not being created when the params were changed. 
2. Data merging was not working for array types. 

Example where merge would fail:
existing data:
```
{
     "permissions": ["rider", "driver"]
}
```
update data:
```
{
     "permissions": ["rider"]
}
```
The reducer would leave the data in the same state it was before because of the merge
